### PR TITLE
More paths commnads

### DIFF
--- a/src/backends/fig_types.f90
+++ b/src/backends/fig_types.f90
@@ -12,6 +12,9 @@ module fig_types
         real(kind=8) :: y
     end type canvas_point
 
+    interface operator (+)
+        module procedure canvas_point_add
+    end interface
     type :: canvas_size
         integer(pixel) :: width
         integer(pixel) :: height
@@ -27,4 +30,11 @@ contains
         pxl%y = p%y * sz%height
     end function to_canvas
 
+    function canvas_point_add(p1, p2) result(result_point)
+        type(canvas_point), intent(in) :: p1, p2
+        type(canvas_point) :: result_point
+        
+        result_point%x = p1%x + p2%x
+        result_point%y = p1%y + p2%y
+    end function canvas_point_add
 end module fig_types

--- a/src/backends/fig_types.f90
+++ b/src/backends/fig_types.f90
@@ -15,6 +15,7 @@ module fig_types
     interface operator (+)
         module procedure canvas_point_add
     end interface
+
     type :: canvas_size
         integer(pixel) :: width
         integer(pixel) :: height
@@ -26,8 +27,13 @@ contains
         type(point), intent(in) :: p
         type(canvas_size), intent(in) :: sz
 
-        pxl%x = p%x * sz%width
-        pxl%y = p%y * sz%height
+        if (FIG_ABSOLUTE_COORDINATES) then
+            pxl%x = p%x
+            pxl%y = p%y 
+        else
+            pxl%x = p%x * sz%width
+            pxl%y = p%y * sz%height
+        end if
     end function to_canvas
 
     function canvas_point_add(p1, p2) result(result_point)

--- a/src/backends/generic_cairo/shapes/path.f90
+++ b/src/backends/generic_cairo/shapes/path.f90
@@ -78,7 +78,18 @@ contains
             case ("Z")
                 real_ind = real_ind + 1
                 call cairo_close_path(cr)
-                
+            case ("H")
+                temp_p%x = real_array(real_ind)
+                p1 = to_canvas(temp_p, canva%size)
+                cur_p%x=p1%x
+                call cairo_line_to(cr, cur_p%x, cur_p%y)
+                real_ind = real_ind + 1
+            case ("V")
+                temp_p%y = real_array(real_ind)
+                p1 = to_canvas(temp_p, canva%size)
+                cur_p%y=p1%y
+                call cairo_line_to(cr, cur_p%x, cur_p%y)
+                real_ind = real_ind + 1
         end select
 
             

--- a/src/backends/generic_cairo/shapes/path.f90
+++ b/src/backends/generic_cairo/shapes/path.f90
@@ -28,20 +28,47 @@ contains
 
         !! TODO need some error handling
         select case (char_array(char_ind))
-            case ("M")
+            case ("M", "m")
                 temp_p%x=real_array(real_ind)
                 temp_p%y=real_array(real_ind+1)
-                cur_p= to_canvas(temp_p,canva%size)
+                if (char_array(char_ind)=="m") then
+                    cur_p= to_canvas(temp_p,canva%size) +cur_p
+                else
+                    cur_p= to_canvas(temp_p,canva%size)
+                end if
                 call cairo_move_to(cr,cur_p%x ,cur_p%y)
                 real_ind = real_ind + 2
-            case ("L")
+            case ("L", "l")
                 temp_p%x=real_array(real_ind)
                 temp_p%y=real_array(real_ind+1)
-                cur_p= to_canvas(temp_p,canva%size)
+                if (char_array(char_ind)=="l") then
+                    cur_p= to_canvas(temp_p,canva%size) +cur_p
+                else
+                    cur_p= to_canvas(temp_p,canva%size)
+                end if
                 call cairo_line_to(cr,cur_p%x ,cur_p%y)
                 real_ind = real_ind + 2
-            case ("C")
-
+            case ("H","h")
+                temp_p%x = real_array(real_ind)
+                p1 = to_canvas(temp_p, canva%size)
+                if (char_array(char_ind)=="h") then
+                    cur_p%x=p1%x+cur_p%x
+                else 
+                    cur_p%x=p1%x
+                end if
+                call cairo_line_to(cr, cur_p%x, cur_p%y)
+                real_ind = real_ind + 1
+            case ("V","v")
+                temp_p%y = real_array(real_ind)
+                p1 = to_canvas(temp_p, canva%size)
+                if (char_array(char_ind)=="v") then
+                    cur_p%y=p1%y+cur_p%y
+                else 
+                    cur_p%y=p1%y
+                end if
+                call cairo_line_to(cr, cur_p%x, cur_p%y)
+                real_ind = real_ind + 1
+            case ("C", "c")
                 temp_p%x=real_array(real_ind)
                 temp_p%y=real_array(real_ind+1)
                 p1= to_canvas(temp_p,canva%size)
@@ -50,46 +77,48 @@ contains
                 p2= to_canvas(temp_p,canva%size)
                 temp_p%x=real_array(real_ind+4)
                 temp_p%y=real_array(real_ind+5)
-                cur_p= to_canvas(temp_p,canva%size)
+                if (char_array(char_ind)=="c") then
+                    p1= p1+cur_p
+                    p2= p2+cur_p
+                    cur_p= to_canvas(temp_p,canva%size)+cur_p
+                else
+                    cur_p= to_canvas(temp_p,canva%size)
+                end if
                 call cairo_curve_to(cr, p1%x, p1%y, p2%x, p2%y, cur_p%x, cur_p%y)
                 real_ind = real_ind + 6
-            case ("Q")
+            case ("Q","q")
                 temp_p%x=real_array(real_ind)
                 temp_p%y=real_array(real_ind+1)
                 p1= to_canvas(temp_p,canva%size)
                 temp_p%x=real_array(real_ind+2)
                 temp_p%y=real_array(real_ind+3)
                 p2= to_canvas(temp_p,canva%size)
+                if (char_array(char_ind)=="q") then
+                    p1= p1+cur_p
+                    p2= p2+cur_p
+                end if
                 call quad_to(cr, cur_p%x, cur_p%y, p1%x, p1%y, p2%x, p2%y)
                 cur_p = p2
                 real_ind = real_ind + 4
-            case ("A")
+            case ("A",'a')
                 temp_p%x=real_array(real_ind)
                 temp_p%y=real_array(real_ind+1)
                 p1= to_canvas(temp_p,canva%size)
                 temp_p%x=real_array(real_ind+5)
                 temp_p%y=real_array(real_ind+6)
                 p2= to_canvas(temp_p,canva%size)
+                if (char_array(char_ind)=="a") then
+                    p1= p1+cur_p
+                    p2= p2+cur_p
+                end if
                 call arc_to(cr, cur_p%x, cur_p%y,p1%x, p1%y,&
                     real_array(real_ind+2), real_array(real_ind+3)>0.1, real_array(real_ind+4)>0.1, p2%x,&
                     p2%y)
                 cur_p = p2
                 real_ind = real_ind + 7
-            case ("Z")
+            case ("Z","z")
                 real_ind = real_ind + 1
                 call cairo_close_path(cr)
-            case ("H")
-                temp_p%x = real_array(real_ind)
-                p1 = to_canvas(temp_p, canva%size)
-                cur_p%x=p1%x
-                call cairo_line_to(cr, cur_p%x, cur_p%y)
-                real_ind = real_ind + 1
-            case ("V")
-                temp_p%y = real_array(real_ind)
-                p1 = to_canvas(temp_p, canva%size)
-                cur_p%y=p1%y
-                call cairo_line_to(cr, cur_p%x, cur_p%y)
-                real_ind = real_ind + 1
         end select
 
             

--- a/src/fig_config.f90
+++ b/src/fig_config.f90
@@ -5,5 +5,7 @@ module fig_config
     !! technically it should be int8 but there are problems with signed integers and bit manipulation
     integer, parameter :: pixel = int32 !! 8 bits per every color channel (r,g,b,a)
     integer, parameter :: rgb_bit_depth = 8
+
+    logical :: FIG_ABSOLUTE_COORDINATES = .false.
 end module fig_config
 

--- a/test/fortran_logo.f90
+++ b/test/fortran_logo.f90
@@ -1,0 +1,87 @@
+program logo_path_test
+    use fig_path
+    use fig_drawing
+    use fig_svg
+    use fig_bitmap
+    use fig_test
+    use fig_rgb_color_constants
+    implicit none
+    integer, parameter :: CANVAS_WIDTH = 200
+    integer, parameter :: CANVAS_HEIGHT = 200
+    character(len=:), allocatable  :: file_name
+    type(drawing) :: canva
+    type(path) :: my_path
+    type(svg_canvas) :: svg_canva
+    type(bitmap_canvas) :: bitmap_canva
+
+    FIG_ABSOLUTE_COORDINATES = .true.
+    call canva%init()
+    file_name= "fortran logo"
+
+    my_path%path_string="m 66.01647,123.09029 &
+        c 0,-2.98216 0.0232,-3.24783 0.284142,-3.25337 &
+        c 0.156278,-0.003 1.698346 ,-0.0723 3.426817,-0.15338 &
+        c 2.783528,-0.13052 3.227886,-0.19014 3.888311,-0.52167 &
+        c 0.522164,-0.26212 0.845509,-0.56896 1.07887,-1.02377&
+        c 0.330889,-0.6449 0.333235,-0.79405 0.333235,-21.18891 &
+        c 0,-19.16494 -0.0188,-20.573793 -0.280899,-21.052796&
+        c -0.35488,-0.648562 -0.970461,-1.135802 -1.726889,-1.366854 &
+        c -0.324547,-0.09913 -2.033124,-0.219157 -3.796837,-0.266719&
+        l -3.20675,-0.08648 V 70.949727 V 67.72311 &
+        h 27.277676 &
+        h 27.277674 &
+        v 12.09635 &
+        v 12.09635 &
+        l -2.88201,-0.01619 &
+        c -1.58511,-0.0089 -3.06468,-0.06699 -3.28794,-0.129079 &
+        c -0.39914,-0.111009 -0.40916,-0.154768 -0.60046,-2.62228 &
+        c -0.24553,-3.166944 -0.44624,-4.569394 -0.9554,-6.675976 &
+        c -1.10082,-4.554462 -3.42356,-7.032127 -7.21648,-7.697813 &
+        c -1.59136,-0.279295 -8.534273,-0.549154 -14.243197,-0.553608 &
+        l -3.937405,-0.0031 &
+        v 9.095131 &
+        v 9.095131 &
+        l 2.070182,-0.102679 &
+        c 2.366865,-0.117396 4.22742,-0.40322 5.125527,-0.787403 &
+        c 0.95651,-0.409167 1.9665,-1.442775 2.43932,-2.496357 &
+        c 0.49398,-1.100746 0.8172,-2.547274 1.07659,-4.818245 &
+        c 0.10201,-0.893019 0.21923,-1.788068 0.2605,-1.988997 &
+        c 0.0747,-0.363787 0.0884,-0.365326 3.238103,-0.365326 &
+        h 3.16306 &
+        v 14.531856 &
+        v 14.531855 &
+        h -3.22343 &
+        h -3.223423 &
+        l -0.10838,-1.67638 &
+        c -0.19627,-3.0357 -0.78736,-5.91064 -1.49764,-7.28416 &
+        c -0.97089,-1.87752 -2.88173,-2.721509 -6.722534,-2.969276 &
+        c -0.848368,-0.05473 -1.784855,-0.137083 -2.081083,-0.183012 &
+        l -0.538596,-0.08351 &
+        l 0.06292,9.142548 &
+        c 0.06636,9.64289 0.09513,10.01966 0.826875,10.82774 &
+        c 0.752359,0.83085 1.191043,0.88792 8.833448,1.14929 &
+        c 0.15537,0.005 0.20296,0.76836 0.20296,3.25429 &
+        v 3.24734 &
+        H 81.684896 &
+        H 66.01647 &
+        Z"
+    my_path%fill_color = FIG_COLOR_WHITE
+    call canva%add_shape(my_path)
+    
+    ! Save to bitmap and SVG
+    call bitmap_canva%init(CANVAS_WIDTH,CANVAS_HEIGHT,file_name)
+    call bitmap_canva%apply_shapes(canva)
+    call bitmap_canva%save_to_png()
+    call bitmap_canva%save_to_ppm()
+    call bitmap_canva%destroy()
+
+    call svg_canva%init(CANVAS_WIDTH,CANVAS_HEIGHT,file_name)
+    call svg_canva%apply_shapes(canva)
+    call svg_canva%save_to_svg()
+    call svg_canva%destroy()
+    call test_both(file_name,bitmap_canva)
+
+
+
+end program logo_path_test
+


### PR DESCRIPTION
![fortran logo](https://github.com/AnonMiraj/fig/assets/54112754/3e37d965-94f6-4d13-9544-4b9317965dec)


There is an oversight in parsing path strings that I need to fix. It involves handling cases where commands can be omitted if they are consecutive.

"L 10 10 20 20" should be parsed as "L 10 10 L 20 20".

I am going to fix this in another PR.

All previous PRs and this one are ready for review.
 @everythingfunctional @perazz.